### PR TITLE
Fix #4: Fix Contribution action menu selection query

### DIFF
--- a/pleaseDeleteContributionsPlease.js
+++ b/pleaseDeleteContributionsPlease.js
@@ -20,7 +20,7 @@ var pleaseDeleteContributionsPlease = function () {
     }
         
     var deleteContribution = function() {
-        [...document.querySelectorAll('div[role="menuitem"][class="action-menu-entry"] > div[class="action-menu-entry-text"]')].forEach( (a) => { 
+        [...document.querySelectorAll('div[class="action-menu-entry-text-container"] > div[class="action-menu-entry-text"]')].forEach( (a) => {
             if (a.innerHTML.includes("Delete")
                 || a.innerHTML.includes("Elimina")) {
                 a.parentElement.style.border = "thick solid red";


### PR DESCRIPTION
The query selection on the master branch does not work on the current
Google Maps version. Instead of looking for a

`<div role="menuitem" class="action-menu-entry" ...>`

it works for me to look for a

`<div class="action-menu-entry-text-container" ...>`

With this change, I could delete all my contributed photos and reviews.